### PR TITLE
[skip ci] Add repo option

### DIFF
--- a/__tests__/getToken.spec.ts
+++ b/__tests__/getToken.spec.ts
@@ -196,4 +196,19 @@ describe('getToken', () => {
     expect(token).toMatchInlineSnapshot('"secret-installation-token-1234"');
     expect(github.isDone()).toBe(true);
   });
+
+  it('Takes a list of repository names', async () => {
+    const repos = ['repo1', 'repo2'];
+    const github = nock(GITHUB_URL).post(getAccessTokensURL(123456)).reply(201, response);
+
+    const { token } = await getToken({
+      appId: APP_ID,
+      installationId: 123456,
+      privateKey: PRIVATE_KEY,
+      repositoryNames: repos,
+    });
+
+    expect(token).toMatchInlineSnapshot('"secret-installation-token-1234"');
+    expect(github.isDone()).toBe(true);
+  });
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -6,6 +6,10 @@ import { getTokenCommand } from '../commands';
 
 program.name(packageJSON.name).description(packageJSON.description).version(packageJSON.version);
 
+function collectRepos(value: string, previous: string[]) {
+  return previous.concat([value]);
+}
+
 program
   .requiredOption('--appId <appID>', 'Github App ID')
   .requiredOption(
@@ -25,6 +29,7 @@ program
     '--baseUrl <baseUrl>',
     'Change the base url for github request. For example if used on a Github Enterprise Server instance.'
   )
+  .option('-r, --repo <name>', 'Allow access to a single repository', collectRepos, [])
 
   .action(getTokenCommand);
 

--- a/src/commands/getToken.ts
+++ b/src/commands/getToken.ts
@@ -21,6 +21,7 @@ interface GetTokenInput {
   installationId: number;
   privateKey: string;
   baseUrl?: string;
+  repositoryNames?: string[];
 }
 type RequestOptions = RequestRequestOptions & Required<{ rawResponse: true }>;
 type PlainRequest = RequestRequestOptions & { rawResponse?: false };
@@ -34,7 +35,7 @@ export async function getToken(
   requestOptions?: PlainRequest
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'>>;
 export async function getToken(
-  { appId, installationId, privateKey, baseUrl }: GetTokenInput,
+  { appId, installationId, privateKey, baseUrl, repositoryNames }: GetTokenInput,
   requestOptions?: PlainRequest | RequestOptions
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'> | AppsCreateInstallationAccessTokenResponse> {
   const key = new NodeRSA(privateKey);
@@ -62,6 +63,7 @@ export async function getToken(
   const response = await octokit.auth({
     type: 'installation',
     installationId,
+    repositoryNames,
   });
 
   if (!isAppsCreateInstallationAccessTokenResponse(response)) {
@@ -76,6 +78,7 @@ type Input = Omit<Command & GetTokenInput, 'privateKey'> & {
   privateKeyLocation?: string;
   privateKey?: string;
   rawResponse?: boolean;
+  repo?: string[];
 };
 
 const isValidInput = (input: Input): boolean => {
@@ -90,7 +93,7 @@ export const command = async (input: Input): Promise<void> => {
   try {
     let privateKey: string;
 
-    const { privateKeyLocation, installationId, appId, rawResponse } = input;
+    const { privateKeyLocation, installationId, appId, rawResponse, baseUrl, repo } = input;
 
     if (!isValidInput(input)) {
       loader.fail('Input is not valid, either privateKey or privateKeyLocation should be provided');
@@ -103,10 +106,13 @@ export const command = async (input: Input): Promise<void> => {
       privateKey = input.privateKey as string;
     }
 
-    const response = await getToken({ privateKey, installationId, appId }, { rawResponse: true });
+    const response = await getToken(
+      { privateKey, installationId, appId, baseUrl, repositoryNames: repo },
+      { rawResponse: true }
+    );
 
     loader.stopAndPersist({
-      text: `The token is: ${response.token} and expires ${response.expiresAt}`,
+      text: `Herr token is: ${response.token} and expires ${response.expiresAt}`,
       symbol: SUCCESS_SYMBOL,
     });
 

--- a/src/commands/getToken.ts
+++ b/src/commands/getToken.ts
@@ -112,7 +112,7 @@ export const command = async (input: Input): Promise<void> => {
     );
 
     loader.stopAndPersist({
-      text: `Herr token is: ${response.token} and expires ${response.expiresAt}`,
+      text: `The token is: ${response.token} and expires ${response.expiresAt}`,
       symbol: SUCCESS_SYMBOL,
     });
 


### PR DESCRIPTION
Adds a "repo" option which can be used to restrict the token scope to only a subset of the repositories that the installed application has been granted. If the option is not given, all repositories are accessible.

```
> github-app-installation-token --appId x --installationId y --privateKeyLocation z --repo blog --repo clojure-notebooka
```